### PR TITLE
Enlarge public display text and mark auto-scroll loop point

### DIFF
--- a/frontend/src/components/PublicDisplay.svelte
+++ b/frontend/src/components/PublicDisplay.svelte
@@ -1,11 +1,17 @@
 <script>
-    import { onMount } from 'svelte';
+    import { onMount, tick } from 'svelte';
     let lot = {};
     let bidders = [];
     let leftColumnBidders = [];
     let rightColumnBidders = [];
+    let shouldScroll = false;
+    let scrollDuration = 10;
+    let viewportEl;
+    let innerEl;
+
     const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
-    const MAX_BIDDERS_PER_COLUMN = 10;
+    // Pixels per second for the scroll; increase to scroll faster
+    const SCROLL_SPEED_PX_PER_SEC = 40;
 
     function distributeBidders(bidderList) {
         if (bidderList.length === 0) {
@@ -13,18 +19,32 @@
             rightColumnBidders = [];
             return;
         }
-
-        if (bidderList.length > MAX_BIDDERS_PER_COLUMN * 2) {
-            const startIndex = bidderList.length - (MAX_BIDDERS_PER_COLUMN * 2);
-            bidderList = bidderList.slice(startIndex);
-        }
-
         const midPoint = Math.ceil(bidderList.length / 2);
         leftColumnBidders = bidderList.slice(0, midPoint);
         rightColumnBidders = bidderList.slice(midPoint);
     }
 
     $: distributeBidders(bidders);
+
+    async function checkOverflow() {
+        await tick();
+        if (!viewportEl || !innerEl) return;
+        // When scrolling, inner contains the list twice; halve to get true content height.
+        const contentHeight = shouldScroll ? innerEl.scrollHeight / 2 : innerEl.scrollHeight;
+        const viewportHeight = viewportEl.clientHeight;
+        const overflowing = contentHeight > viewportHeight;
+        if (overflowing !== shouldScroll) {
+            shouldScroll = overflowing;
+            // The separator only renders once shouldScroll flips, which changes
+            // the measured height; wait for that DOM update before timing it.
+            await tick();
+        }
+        if (shouldScroll) {
+            scrollDuration = (innerEl.scrollHeight / 2) / SCROLL_SPEED_PX_PER_SEC;
+        }
+    }
+
+    $: bidders, checkOverflow();
 
     async function fetchInitialState() {
         try {
@@ -46,7 +66,7 @@
             if (data.lot) lot = data.lot;
             if (Array.isArray(data.bidders)) bidders = data.bidders;
         };
-        
+
         fetchInitialState();
     });
 </script>
@@ -60,81 +80,92 @@
         font-family: Arial, sans-serif;
         box-sizing: border-box;
     }
-    
+
     .header {
         text-align: center;
         border: 2px solid black;
         padding: 10px;
         margin-bottom: 20px;
-        font-size: 1.5rem;
+        font-size: 3rem;
         font-weight: bold;
         flex-shrink: 0;
     }
-    
+
     .content {
         display: flex;
         flex-direction: column;
         flex: 1;
         min-height: 0;
     }
-    
+
     .bidders-section {
         flex: 1;
         display: flex;
         flex-direction: column;
         min-height: 0;
     }
-    
-    .bidders-container {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0 40px;
+
+    .bidders-viewport {
         flex: 1;
         overflow: hidden;
         min-height: 0;
     }
-    
-    .bidders-column {
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
+
+    .bidders-inner.scrolling {
+        animation: scroll-loop var(--scroll-duration, 10s) linear infinite;
     }
-    
+
+    @keyframes scroll-loop {
+        0%   { transform: translateY(0); }
+        100% { transform: translateY(-50%); }
+    }
+
+    .scroll-separator {
+        margin: 24px 0;
+        border-top: 6px solid #999;
+    }
+
+    .bidders-container {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0 40px;
+    }
+
     .bidder-item {
         margin-bottom: 8px;
-        font-size: 1.265rem;
+        font-size: 2.53rem;
         line-height: 1.3;
         word-wrap: break-word;
         text-indent: -2em;
         padding-left: 2em;
         flex-shrink: 0;
     }
-    
+
     .bidder-number {
         display: inline-block;
         min-width: 2em;
         text-indent: 0;
     }
-    
+
     .lot-info {
         border: 2px solid black;
         padding: 10px;
         margin-top: 20px;
         flex-shrink: 0;
     }
-    
+
     .lot-info table {
         width: 100%;
         border-collapse: collapse;
     }
-    
+
     .lot-info th, .lot-info td {
         border: 1px solid black;
         padding: 8px;
         text-align: center;
-        font-size: 1.2rem;
+        font-size: 2.4rem;
     }
-    
+
     .lot-info th {
         background-color: #f0f0f0;
         font-weight: bold;
@@ -145,29 +176,60 @@
     <div class="header">
         Tippecanoe County 4-H Livestock Auction
     </div>
-    
+
     <div class="content">
         <div class="bidders-section">
             {#if bidders.length > 0}
-                <div class="bidders-container">
-                    <div class="bidders-column">
-                        {#each leftColumnBidders as bidder}
-                            <div class="bidder-item">
-                                <span class="bidder-number">{bidder.Identifier}</span>	{bidder.Name}
+                <div class="bidders-viewport" bind:this={viewportEl}>
+                    <div
+                        class="bidders-inner"
+                        class:scrolling={shouldScroll}
+                        style="--scroll-duration: {scrollDuration}s"
+                        bind:this={innerEl}
+                    >
+                        <div class="bidders-container">
+                            <div class="bidders-column">
+                                {#each leftColumnBidders as bidder}
+                                    <div class="bidder-item">
+                                        <span class="bidder-number">{bidder.Identifier}</span>	{bidder.Name}
+                                    </div>
+                                {/each}
                             </div>
-                        {/each}
-                    </div>
-                    <div class="bidders-column">
-                        {#each rightColumnBidders as bidder}
-                            <div class="bidder-item">
-                                <span class="bidder-number">{bidder.Identifier}</span>	{bidder.Name}
+                            <div class="bidders-column">
+                                {#each rightColumnBidders as bidder}
+                                    <div class="bidder-item">
+                                        <span class="bidder-number">{bidder.Identifier}</span>	{bidder.Name}
+                                    </div>
+                                {/each}
                             </div>
-                        {/each}
+                        </div>
+                        {#if shouldScroll}
+                            <!-- Trailing separator on each copy keeps both loop halves the same
+                                 height ([list][separator] x2) so translateY(-50%) wraps seamlessly. -->
+                            <div class="scroll-separator" aria-hidden="true"></div>
+                            <div class="bidders-container" aria-hidden="true">
+                                <div class="bidders-column">
+                                    {#each leftColumnBidders as bidder}
+                                        <div class="bidder-item">
+                                            <span class="bidder-number">{bidder.Identifier}</span>	{bidder.Name}
+                                        </div>
+                                    {/each}
+                                </div>
+                                <div class="bidders-column">
+                                    {#each rightColumnBidders as bidder}
+                                        <div class="bidder-item">
+                                            <span class="bidder-number">{bidder.Identifier}</span>	{bidder.Name}
+                                        </div>
+                                    {/each}
+                                </div>
+                            </div>
+                            <div class="scroll-separator" aria-hidden="true"></div>
+                        {/if}
                     </div>
                 </div>
             {/if}
         </div>
-        
+
         <div class="lot-info">
             <table>
                 <thead>


### PR DESCRIPTION
## Summary
- Roughly doubled font sizes on the public auction display (header, bidder list, lot-info table) — the previous sizes were hard to read on the projector.
- Added a solid divider between the end of the bidder list and its repeated start, shown only when the list actually overflows and auto-scrolls, so viewers can tell the list looped rather than continuing.
- Tightened the scroll-duration calculation so it re-measures after the divider is added to the DOM, keeping scroll speed accurate.

## Test plan
- [ ] `npm run build` in `frontend/` (already verified clean)
- [ ] Load `/public` with a short bidder list — confirm no scrolling and no divider
- [ ] Load `/public` with a long bidder list that overflows the viewport — confirm smooth auto-scroll with a visible divider at the loop point
- [ ] Confirm text is comfortably readable from a distance (target: projector screen)