### PR TITLE
Replace hardcoded admin bypass with a real seeded DB user

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -14,9 +14,6 @@ ACCESS_TOKEN_EXPIRE_HOURS = 24
 
 security = HTTPBearer()
 
-ADMIN_USERNAME = "admin"
-ADMIN_PASSWORD_HASH = _bcrypt.hashpw(b"admin123", _bcrypt.gensalt()).decode("utf-8")
-
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return _bcrypt.checkpw(
         plain_password.encode("utf-8"),
@@ -55,17 +52,10 @@ def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
     except InvalidTokenError:
         raise credentials_exception
 
-def authenticate_user(username: str, password: str, db: Session = None) -> bool:
-    if username == ADMIN_USERNAME and verify_password(password, ADMIN_PASSWORD_HASH):
-        return True
-
-    if db:
-        from database import User
-        user = db.query(User).filter(User.username == username).first()
-        if user and verify_password(password, user.password_hash):
-            return True
-
-    return False
+def authenticate_user(username: str, password: str, db: Session) -> bool:
+    from database import User
+    user = db.query(User).filter(User.username == username).first()
+    return bool(user and verify_password(password, user.password_hash))
 
 def create_user(username: str, password: str, db: Session) -> bool:
     from database import User
@@ -98,11 +88,12 @@ def get_all_users(db: Session):
 def delete_user(username: str, db: Session) -> bool:
     from database import User
 
-    if username == ADMIN_USERNAME:
-        return False
-
     user = db.query(User).filter(User.username == username).first()
     if not user:
+        return False
+
+    # Never delete the last remaining account — that would lock everyone out.
+    if db.query(User).count() <= 1:
         return False
 
     db.delete(user)

--- a/backend/database.py
+++ b/backend/database.py
@@ -81,7 +81,25 @@ def init_database():
     os.makedirs("data", exist_ok=True)
     Base.metadata.create_all(bind=engine)
     _ensure_theme_column()
+    _ensure_default_admin()
     logger.info("Database initialized")
+
+def _ensure_default_admin():
+    """Seed a real `admin` row on a fresh database so the account is a normal
+    DB-managed user from the start — visible in /api/users and changeable via
+    the usual change-password flow, instead of a hardcoded bypass that never
+    shows up there. Only runs when the users table is empty, so it never
+    overwrites an existing account."""
+    from auth import get_password_hash
+
+    db = SessionLocal()
+    try:
+        if db.query(User).count() == 0:
+            db.add(User(username="admin", password_hash=get_password_hash("admin123"), is_admin=True))
+            db.commit()
+            logger.info("No users found — created default admin user (admin/admin123). Change this password after logging in.")
+    finally:
+        db.close()
 
 def _ensure_theme_column():
     """create_all() only creates missing tables, not missing columns on

--- a/backend/main.py
+++ b/backend/main.py
@@ -407,7 +407,7 @@ async def delete_user_endpoint(username: str, db: Session = Depends(get_db), use
         await broadcast_message({"type": "log", "message": f"Deleted user: {username}"})
         return {"message": f"User {username} deleted successfully"}
     else:
-        raise HTTPException(status_code=400, detail="Cannot delete user (user not found or is default admin)")
+        raise HTTPException(status_code=400, detail="Cannot delete user (user not found, or this is the last remaining account)")
 
 @app.websocket("/ws")
 async def websocket_endpoint(ws: WebSocket):

--- a/frontend/src/components/UserManagement.svelte
+++ b/frontend/src/components/UserManagement.svelte
@@ -202,12 +202,12 @@
               <td>{user.username}</td>
               <td>{new Date(user.created_at).toLocaleString()}</td>
               <td>
-                {#if user.username !== 'admin'}
+                {#if users.length > 1}
                   <button class="btn btn-danger" on:click={() => deleteUser(user.username)} disabled={loading}>
                     Delete
                   </button>
                 {:else}
-                  <span style="color: #6c757d;">Default Admin</span>
+                  <span style="color: #6c757d;">Only user — cannot delete</span>
                 {/if}
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- The `admin`/`admin123` login was a special-cased bypass in `authenticate_user()` that never became an actual `users` table row — so it never showed up in `GET /api/users`, and `change_user_password("admin", ...)` always 404'd. The account could never actually be changed. Confirmed this is the exact state of the live production database (zero rows in `users`).
- `init_database()` now seeds a real `admin`/`admin123` row whenever the `users` table is empty (fresh container spin-up, or upgrading an existing database with no users), so it's a normal DB-managed account from the start: visible in User Management, changeable via the existing change-password flow. Re-running startup is a no-op once any user exists.
- Generalized `delete_user()`'s protection from "you can't delete the literal username `admin`" to "you can't delete the last remaining account" — the actual invariant worth protecting, now correct regardless of what the account is named.
- Updated `UserManagement.svelte` and the delete-user error message to match.

## Test plan
- [x] Verified against a copy of the live production `auction.db` (which has zero `users` rows today): seeding creates `admin`/`admin123`, it appears in `GET /api/users`, password change succeeds, old password is rejected afterward and the new one works
- [x] Verified deletion is blocked while it's the only account, and allowed once a second account exists
- [x] Verified restarting the server does not re-seed or duplicate the admin row
- [x] Verified a brand-new/empty database seeds correctly on first boot
- [x] `npm run build` succeeds cleanly
- [x] Confirmed live by the user: successfully changed the admin password through the running app