### PR TITLE
Add FairEntry auto-sync for the buyer list

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -47,6 +47,21 @@ class AuctionSession(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     is_active = Column(Boolean, default=True)
 
+class FairEntrySettings(Base):
+    __tablename__ = "fairentry_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String)
+    password_encrypted = Column(String)
+    fair_title = Column(String)
+    sync_enabled = Column(Boolean, default=False)
+    sync_interval_minutes = Column(Integer, default=15)
+    last_sync_at = Column(DateTime, nullable=True)
+    last_sync_status = Column(String, default="never")
+    last_sync_message = Column(Text, nullable=True)
+    consecutive_failures = Column(Integer, default=0)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
 class User(Base):
     __tablename__ = "users"
     
@@ -119,3 +134,13 @@ def get_or_create_session(db):
         db.commit()
         db.refresh(session)
     return session
+
+def get_or_create_fairentry_settings(db):
+    """Get or create the singleton FairEntry sync settings row"""
+    settings = db.query(FairEntrySettings).first()
+    if not settings:
+        settings = FairEntrySettings()
+        db.add(settings)
+        db.commit()
+        db.refresh(settings)
+    return settings

--- a/backend/fairentry_sync.py
+++ b/backend/fairentry_sync.py
@@ -1,0 +1,171 @@
+import asyncio
+import base64
+import hashlib
+import logging
+import os
+from datetime import datetime, timedelta
+
+from cryptography.fernet import Fernet, InvalidToken
+from fairentry_api import FairEntryClient, FairEntryError
+
+from database import Buyer, FairEntrySettings, SessionLocal, get_or_create_fairentry_settings
+from ws_manager import broadcast_message
+
+logger = logging.getLogger("adbackend")
+
+FAILURE_THRESHOLD = 3
+SYNC_CHECK_TICK_SECONDS = 30
+
+SECRET_KEY = os.getenv("SECRET_KEY", "your-secret-key-here-change-in-production")
+_FERNET = Fernet(base64.urlsafe_b64encode(hashlib.sha256(SECRET_KEY.encode("utf-8")).digest()))
+
+
+def encrypt_password(plain: str) -> str:
+    return _FERNET.encrypt(plain.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_password(cipher: str) -> str:
+    return _FERNET.decrypt(cipher.encode("utf-8")).decode("utf-8")
+
+
+def settings_to_dict(settings: FairEntrySettings) -> dict:
+    return {
+        "username": settings.username,
+        "fair_title": settings.fair_title,
+        "sync_enabled": settings.sync_enabled,
+        "sync_interval_minutes": settings.sync_interval_minutes,
+        # last_sync_at is stored naive UTC (datetime.utcnow()); tag it explicitly
+        # so the browser's Date parser treats it as UTC rather than local time,
+        # which lets toLocaleString() convert it to the viewer's timezone correctly.
+        "last_sync_at": settings.last_sync_at.isoformat() + "Z" if settings.last_sync_at else None,
+        "last_sync_status": settings.last_sync_status,
+        "last_sync_message": settings.last_sync_message,
+        "consecutive_failures": settings.consecutive_failures,
+        "has_password": bool(settings.password_encrypted),
+    }
+
+
+_sync_lock = asyncio.Lock()
+
+
+async def perform_sync(db) -> dict:
+    """Fetch the buyer list from FairEntry and upsert it into the Buyer table.
+
+    Reads credentials/fair title fresh from the DB every call (rather than
+    reusing a persisted client/session), so edits made in the admin UI take
+    effect on the very next sync without a restart.
+    """
+    async with _sync_lock:
+        return await _perform_sync_locked(db)
+
+
+async def _perform_sync_locked(db) -> dict:
+    settings = get_or_create_fairentry_settings(db)
+
+    if not (settings.username and settings.password_encrypted and settings.fair_title):
+        result = {"status": "skipped", "message": "FairEntry credentials not configured"}
+        await _broadcast_status(db, settings, result)
+        return result
+
+    try:
+        password = decrypt_password(settings.password_encrypted)
+    except InvalidToken:
+        result = {"status": "error", "message": "Stored password could not be decrypted; re-enter it"}
+        await _record_failure(db, settings, result["message"])
+        await _broadcast_status(db, settings, result)
+        return result
+
+    try:
+        client = FairEntryClient()
+        await asyncio.to_thread(client.authenticate, settings.username, password, settings.fair_title)
+        fe_buyers = await asyncio.to_thread(client.get_buyers, True)
+    except FairEntryError as e:
+        result = {"status": "error", "message": str(e)}
+        await _record_failure(db, settings, result["message"])
+        await _broadcast_status(db, settings, result)
+        return result
+
+    existing_buyers = {buyer.identifier: buyer for buyer in db.query(Buyer).all()}
+    added_count = 0
+    updated_count = 0
+    skipped = []
+
+    for fe_buyer in fe_buyers:
+        try:
+            identifier_int = int(fe_buyer.identifier)
+        except (TypeError, ValueError):
+            skipped.append(fe_buyer.identifier)
+            continue
+
+        name_str = fe_buyer.name or ""
+
+        if identifier_int in existing_buyers:
+            existing_buyer = existing_buyers[identifier_int]
+            if existing_buyer.name != name_str:
+                existing_buyer.name = name_str
+                updated_count += 1
+        else:
+            db.add(Buyer(identifier=identifier_int, name=name_str))
+            added_count += 1
+
+    message = f"FairEntry sync: {added_count} added, {updated_count} updated"
+    if skipped:
+        message += f" ({len(skipped)} buyer(s) skipped - non-numeric identifier)"
+        logger.warning(f"FairEntry sync skipped non-numeric identifiers: {skipped}")
+
+    settings.last_sync_at = datetime.utcnow()
+    settings.last_sync_status = "success"
+    settings.last_sync_message = message
+    settings.consecutive_failures = 0
+    db.commit()
+
+    logger.info(message)
+    result = {"status": "success", "message": message, "added": added_count, "updated": updated_count}
+    await _broadcast_status(db, settings, result)
+    return result
+
+
+async def _record_failure(db, settings: FairEntrySettings, error_message: str):
+    settings.last_sync_at = datetime.utcnow()
+    settings.last_sync_status = "error"
+    settings.consecutive_failures = (settings.consecutive_failures or 0) + 1
+
+    if settings.consecutive_failures >= FAILURE_THRESHOLD:
+        settings.sync_enabled = False
+        settings.last_sync_message = (
+            f"{error_message} (auto-disabled after {FAILURE_THRESHOLD} consecutive failures)"
+        )
+    else:
+        settings.last_sync_message = error_message
+
+    db.commit()
+    logger.error(f"FairEntry sync failed: {settings.last_sync_message}")
+
+
+async def _broadcast_status(db, settings: FairEntrySettings, result: dict):
+    await broadcast_message({"type": "fairentry_status", **settings_to_dict(settings)})
+    if result.get("status") == "success":
+        await broadcast_message({"type": "buyers_updated"})
+    if result.get("status") in ("success", "error"):
+        await broadcast_message({"type": "log", "message": result["message"]})
+
+
+async def fairentry_sync_loop():
+    """Background task: periodically checks whether an auto-sync is due."""
+    while True:
+        await asyncio.sleep(SYNC_CHECK_TICK_SECONDS)
+        db = SessionLocal()
+        try:
+            settings = get_or_create_fairentry_settings(db)
+            if not settings.sync_enabled:
+                continue
+
+            interval = timedelta(minutes=settings.sync_interval_minutes or 15)
+            if settings.last_sync_at and datetime.utcnow() - settings.last_sync_at < interval:
+                continue
+
+            await perform_sync(db)
+        except Exception:
+            logger.exception("Unexpected error in FairEntry sync loop")
+        finally:
+            db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from pathlib import Path
 import logging.config
@@ -15,11 +16,15 @@ import shutil
 from pathlib import Path
 from sqlalchemy.orm import Session
 from database import (
-    init_database, get_db, get_or_create_session,
+    init_database, get_db, get_or_create_session, get_or_create_fairentry_settings,
     SaleProgram, Buyer, BidderLot, AuctionSession, User,
     ALLOWED_THEMES
 )
 from auth import authenticate_user, create_access_token, require_auth, create_user, change_user_password, get_all_users, delete_user
+from fairentry_sync import (
+    encrypt_password, perform_sync, fairentry_sync_loop, settings_to_dict
+)
+from ws_manager import websockets, broadcast_message
 
 class LoginRequest(BaseModel):
     username: str
@@ -31,6 +36,15 @@ class LoginResponse(BaseModel):
 
 class ThemeRequest(BaseModel):
     theme: str
+
+class FairEntrySettingsRequest(BaseModel):
+    username: str
+    password: str | None = None
+    fair_title: str
+    sync_interval_minutes: int
+
+class FairEntrySyncToggleRequest(BaseModel):
+    enabled: bool
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -65,7 +79,12 @@ if os.path.exists(frontend_dist_path):
 
 init_database()
 
-websockets = []
+@app.on_event("startup")
+async def start_fairentry_sync_loop():
+    # Keep a strong reference on app.state - asyncio only holds a weak
+    # reference to tasks, so an unreferenced task can be garbage collected
+    # mid-run, silently killing the background loop.
+    app.state.fairentry_sync_task = asyncio.create_task(fairentry_sync_loop())
 
 @app.post("/api/auth/login")
 async def login(login_request: LoginRequest, db: Session = Depends(get_db)):
@@ -152,6 +171,16 @@ async def upload_buyer_list(file: UploadFile = File(...), db: Session = Depends(
     db.commit()
     message = f"Buyer list processed: {added_count} added, {updated_count} updated"
     logger.info(message)
+
+    fairentry_settings = get_or_create_fairentry_settings(db)
+    if fairentry_settings.sync_enabled:
+        fairentry_settings.sync_enabled = False
+        db.commit()
+        disable_message = "Auto-sync disabled: manual Buyer List upload took precedence"
+        logger.info(disable_message)
+        await broadcast_message({"type": "fairentry_status", **settings_to_dict(fairentry_settings)})
+        await broadcast_message({"type": "log", "message": disable_message})
+
     await broadcast_state(db)
     await broadcast_message({"type": "log", "message": message})
     return {"message": message, "added": added_count, "updated": updated_count}
@@ -178,6 +207,48 @@ async def get_buyers(db: Session = Depends(get_db)):
         }
         for buyer in buyers
     ]
+
+@app.get("/api/fairentry/settings")
+async def get_fairentry_settings_endpoint(db: Session = Depends(get_db), user: dict = Depends(require_auth)):
+    settings = get_or_create_fairentry_settings(db)
+    return settings_to_dict(settings)
+
+@app.post("/api/fairentry/settings")
+async def update_fairentry_settings(request: FairEntrySettingsRequest, db: Session = Depends(get_db), user: dict = Depends(require_auth)):
+    settings = get_or_create_fairentry_settings(db)
+    settings.username = request.username
+    settings.fair_title = request.fair_title
+    settings.sync_interval_minutes = request.sync_interval_minutes
+    if request.password:
+        settings.password_encrypted = encrypt_password(request.password)
+    settings.consecutive_failures = 0
+    db.commit()
+
+    await broadcast_message({"type": "fairentry_status", **settings_to_dict(settings)})
+    await broadcast_message({"type": "log", "message": "FairEntry sync settings updated"})
+    return settings_to_dict(settings)
+
+@app.post("/api/fairentry/sync-toggle")
+async def toggle_fairentry_sync(request: FairEntrySyncToggleRequest, db: Session = Depends(get_db), user: dict = Depends(require_auth)):
+    settings = get_or_create_fairentry_settings(db)
+    settings.sync_enabled = request.enabled
+    if request.enabled:
+        settings.consecutive_failures = 0
+    db.commit()
+
+    message = f"FairEntry auto-sync {'enabled' if request.enabled else 'disabled'}"
+    await broadcast_message({"type": "fairentry_status", **settings_to_dict(settings)})
+    await broadcast_message({"type": "log", "message": message})
+
+    if request.enabled:
+        await perform_sync(db)
+
+    return settings_to_dict(settings)
+
+@app.post("/api/fairentry/sync-now")
+async def sync_fairentry_now(db: Session = Depends(get_db), user: dict = Depends(require_auth)):
+    result = await perform_sync(db)
+    return result
 
 @app.get("/api/state")
 async def get_current_state(db: Session = Depends(get_db)):
@@ -413,10 +484,12 @@ async def delete_user_endpoint(username: str, db: Session = Depends(get_db), use
 async def websocket_endpoint(ws: WebSocket):
     await ws.accept()
     websockets.append(ws)
+    logger.info(f"WS connected, total clients={len(websockets)}")
     try:
         while True:
             await ws.receive_text()
-    except:
+    except Exception as e:
+        logger.info(f"WS disconnected ({e!r}), total clients={len(websockets) - 1}")
         websockets.remove(ws)
 
 async def broadcast_state(db: Session, bid_update=False):
@@ -442,13 +515,6 @@ async def broadcast_state(db: Session, bid_update=False):
     message_type = "bid_update" if bid_update else "state"
     state = {"type": message_type, "lot": lot_info, "bidders": bidder_info, "theme": session.theme}
     await broadcast_message(state)
-
-async def broadcast_message(message):
-    for ws in websockets:
-        try:
-            await ws.send_json(message)
-        except:
-            websockets.remove(ws)
 
 @app.get("/{full_path:path}")
 async def serve_spa(full_path: str):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ sqlalchemy==2.0.49
 PyJWT==2.12.1
 cryptography==46.0.7
 bcrypt==5.0.0
+fairentry-api @ git+https://github.com/tippe4hexhibit/fairentry_api.git@v0.2.0

--- a/backend/ws_manager.py
+++ b/backend/ws_manager.py
@@ -1,0 +1,15 @@
+import logging
+
+logger = logging.getLogger("adbackend")
+
+websockets = []
+
+
+async def broadcast_message(message):
+    logger.info(f"Broadcasting type={message.get('type')} to {len(websockets)} client(s)")
+    for ws in list(websockets):
+        try:
+            await ws.send_json(message)
+        except Exception as e:
+            logger.info(f"Broadcast send failed ({e!r}), dropping client")
+            websockets.remove(ws)

--- a/frontend/src/components/AdminConsole.svelte
+++ b/frontend/src/components/AdminConsole.svelte
@@ -18,6 +18,7 @@
   let logMessages = [];
   let currentTab = 'main';
   let theme = DEFAULT_THEME;
+  let fairEntrySettings = {};
   const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
 
   async function fetchSaleData() {
@@ -39,6 +40,15 @@
     } catch (error) {
       console.error('Failed to fetch buyer data:', error);
       buyerData = [];
+    }
+  }
+
+  async function fetchFairEntrySettings() {
+    try {
+      const res = await makeAuthenticatedRequest(`${API_BASE}/api/fairentry/settings`);
+      fairEntrySettings = await res.json();
+    } catch (error) {
+      console.error('Failed to fetch FairEntry settings:', error);
     }
   }
 
@@ -76,7 +86,18 @@
       }
     }
 
+    connectWebSocket();
+
+    // Fetch initial data on mount
+    fetchSaleData();
+    fetchBuyerData();
+    fetchCurrentState();
+    fetchFairEntrySettings();
+  });
+
+  function connectWebSocket() {
     ws = new WebSocket(API_BASE.replace('http', 'ws') + '/ws');
+
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
       const timestamp = new Date().toLocaleTimeString();
@@ -101,13 +122,30 @@
         }
       }
       if (data.theme) theme = data.theme;
+
+      if (data.type === 'fairentry_status') {
+        const { type, ...rest } = data;
+        fairEntrySettings = rest;
+      }
+      if (data.type === 'buyers_updated') {
+        fetchBuyerData();
+      }
     };
-    
-    // Fetch initial data on mount
-    fetchSaleData();
-    fetchBuyerData();
-    fetchCurrentState();
-  });
+
+    // The connection can drop silently (backend restart, network blip, laptop
+    // sleep) with no user-visible error - without a reconnect, this screen
+    // would keep showing stale lot/bid/FairEntry state indefinitely. Re-fetch
+    // everything on reconnect to catch up on whatever was missed while down.
+    ws.onclose = () => {
+      setTimeout(() => {
+        connectWebSocket();
+        fetchSaleData();
+        fetchBuyerData();
+        fetchCurrentState();
+        fetchFairEntrySettings();
+      }, 2000);
+    };
+  }
 
   async function addBidder() {
     if (bidderNumber) {
@@ -149,6 +187,7 @@
         alert('Upload complete');
         await fetchSaleData();
         await fetchBuyerData();
+        await fetchFairEntrySettings();
       } else {
         const error = await response.json();
         alert(`Upload failed: ${error.detail}`);
@@ -172,6 +211,54 @@
       }
     } catch (error) {
       alert('Undo failed: ' + error.message);
+    }
+  }
+
+  async function handleSaveFairEntrySettings(settings) {
+    try {
+      const response = await makeAuthenticatedRequest(`${API_BASE}/api/fairentry/settings`, {
+        method: 'POST',
+        body: JSON.stringify(settings)
+      });
+      if (response.ok) {
+        fairEntrySettings = await response.json();
+      } else {
+        const error = await response.json();
+        alert(`Failed to save FairEntry settings: ${error.detail}`);
+      }
+    } catch (error) {
+      alert('Failed to save FairEntry settings: ' + error.message);
+    }
+  }
+
+  async function handleToggleFairEntrySync(enabled) {
+    try {
+      const response = await makeAuthenticatedRequest(`${API_BASE}/api/fairentry/sync-toggle`, {
+        method: 'POST',
+        body: JSON.stringify({ enabled })
+      });
+      if (response.ok) {
+        fairEntrySettings = await response.json();
+      } else {
+        const error = await response.json();
+        alert(`Failed to toggle FairEntry sync: ${error.detail}`);
+      }
+    } catch (error) {
+      alert('Failed to toggle FairEntry sync: ' + error.message);
+    }
+  }
+
+  async function handleSyncFairEntryNow() {
+    try {
+      const response = await makeAuthenticatedRequest(`${API_BASE}/api/fairentry/sync-now`, {
+        method: 'POST'
+      });
+      const result = await response.json();
+      await fetchFairEntrySettings();
+      await fetchBuyerData();
+      return result;
+    } catch (error) {
+      return { message: 'Sync failed: ' + error.message };
     }
   }
 
@@ -243,7 +330,14 @@
   {:else if currentTab === 'sale'}
     <SaleList {saleData} onFileUpload={handleFileUpload} />
   {:else if currentTab === 'buyers'}
-    <BuyerList {buyerData} onFileUpload={handleFileUpload} />
+    <BuyerList
+      {buyerData}
+      onFileUpload={handleFileUpload}
+      {fairEntrySettings}
+      onSaveFairEntrySettings={handleSaveFairEntrySettings}
+      onToggleFairEntrySync={handleToggleFairEntrySync}
+      onSyncFairEntryNow={handleSyncFairEntryNow}
+    />
   {:else if currentTab === 'users'}
     <UserManagement />
   {:else if currentTab === 'preferences'}

--- a/frontend/src/components/BuyerList.svelte
+++ b/frontend/src/components/BuyerList.svelte
@@ -1,7 +1,13 @@
 <script>
+  import FairEntrySync from './FairEntrySync.svelte';
+
   export let buyerData = [];
   export let onFileUpload;
-  
+  export let fairEntrySettings = {};
+  export let onSaveFairEntrySettings;
+  export let onToggleFairEntrySync;
+  export let onSyncFairEntryNow;
+
   $: sortedBuyerData = (buyerData || []).sort((a, b) => {
     const aId = parseInt(a.Identifier) || 0;
     const bId = parseInt(b.Identifier) || 0;
@@ -18,6 +24,13 @@
   .drop-zone { border: 2px dashed #888; padding: 2rem; margin-top: 1rem; text-align: center; background: #fff; font-weight: bold; color: #555; }
   .drop-zone:hover { background: #eef; border-color: #55f; cursor: pointer; }
 </style>
+
+<FairEntrySync
+  settings={fairEntrySettings}
+  onSaveSettings={onSaveFairEntrySettings}
+  onToggleSync={onToggleFairEntrySync}
+  onSyncNow={onSyncFairEntryNow}
+/>
 
 <div class="section">
   <h3>Buyer List ({(buyerData || []).length} buyers)</h3>

--- a/frontend/src/components/FairEntrySync.svelte
+++ b/frontend/src/components/FairEntrySync.svelte
@@ -1,0 +1,145 @@
+<script>
+  export let settings = {};
+  export let onSaveSettings;
+  export let onToggleSync;
+  export let onSyncNow;
+
+  let username = '';
+  let password = '';
+  let fairTitle = '';
+  let syncIntervalMinutes = 15;
+  let saving = false;
+  let syncing = false;
+  let toggling = false;
+  let syncNowMessage = '';
+
+  let initialized = false;
+  $: if (!initialized && settings && settings.username !== undefined) {
+    username = settings.username || '';
+    fairTitle = settings.fair_title || '';
+    syncIntervalMinutes = settings.sync_interval_minutes || 15;
+    initialized = true;
+  }
+
+  async function saveSettings() {
+    saving = true;
+    try {
+      await onSaveSettings({ username, password, fair_title: fairTitle, sync_interval_minutes: syncIntervalMinutes });
+      password = '';
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function toggleSync() {
+    toggling = true;
+    try {
+      await onToggleSync(!settings.sync_enabled);
+    } finally {
+      toggling = false;
+    }
+  }
+
+  async function syncNow() {
+    syncing = true;
+    syncNowMessage = '';
+    try {
+      const result = await onSyncNow();
+      syncNowMessage = result && result.message ? result.message : '';
+    } finally {
+      syncing = false;
+    }
+  }
+
+  function formatTimestamp(iso) {
+    if (!iso) return 'never';
+    return new Date(iso).toLocaleString();
+  }
+</script>
+
+<style>
+  .section { margin: 1rem 0; padding: 1rem; border: 1px solid #ccc; border-radius: 8px; background: #f9f9f9; }
+  .form-group { margin: 0.5rem 0; }
+  .form-group label { display: block; margin-bottom: 0.25rem; font-weight: bold; }
+  .form-group input { width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
+  .btn { padding: 0.5rem 1rem; background: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; margin-right: 0.5rem; }
+  .btn:hover:not(:disabled) { background: #0056b3; }
+  .btn:disabled { background: #6c757d; cursor: not-allowed; }
+  .btn-toggle-on { background: #28a745; }
+  .btn-toggle-on:hover:not(:disabled) { background: #1e7e34; }
+  .btn-toggle-off { background: #6c757d; }
+  .status { margin-top: 1rem; padding: 0.75rem; border-radius: 4px; background: white; border: 1px solid #ddd; }
+  .status-row { display: flex; justify-content: space-between; margin: 0.25rem 0; }
+  .badge { padding: 0.15rem 0.5rem; border-radius: 4px; font-weight: bold; font-size: 0.85rem; }
+  .badge-on { background: #d4edda; color: #155724; }
+  .badge-off { background: #e2e3e5; color: #383d41; }
+  .status-success { color: #28a745; }
+  .status-error { color: #dc3545; }
+  .sync-now-msg { margin-top: 0.5rem; font-style: italic; }
+</style>
+
+<div class="section">
+  <h3>FairEntry Auto-Sync</h3>
+
+  <div class="form-group">
+    <label for="fe-username">FairEntry Username</label>
+    <input id="fe-username" type="text" bind:value={username} placeholder="username@example.com" />
+  </div>
+  <div class="form-group">
+    <label for="fe-password">FairEntry Password</label>
+    <input id="fe-password" type="password" bind:value={password} placeholder={settings.has_password ? '•••••• (saved — leave blank to keep)' : 'Enter password'} />
+  </div>
+  <div class="form-group">
+    <label for="fe-fair-title">Fair Title</label>
+    <input id="fe-fair-title" type="text" bind:value={fairTitle} placeholder="2026 County Fair" />
+  </div>
+  <div class="form-group">
+    <label for="fe-interval">Sync Interval (minutes)</label>
+    <input id="fe-interval" type="number" min="1" bind:value={syncIntervalMinutes} />
+  </div>
+
+  <button class="btn" on:click={saveSettings} disabled={saving}>
+    {saving ? 'Saving...' : 'Save Settings'}
+  </button>
+  <button
+    class="btn"
+    class:btn-toggle-on={!settings.sync_enabled}
+    class:btn-toggle-off={settings.sync_enabled}
+    on:click={toggleSync}
+    disabled={toggling}
+  >
+    {settings.sync_enabled ? 'Disable Auto-Sync' : 'Enable Auto-Sync'}
+  </button>
+  <button class="btn" on:click={syncNow} disabled={syncing}>
+    {syncing ? 'Syncing...' : 'Sync Now'}
+  </button>
+
+  {#if syncNowMessage}
+    <p class="sync-now-msg">{syncNowMessage}</p>
+  {/if}
+
+  <div class="status">
+    <div class="status-row">
+      <span>Auto-Sync:</span>
+      <span class="badge" class:badge-on={settings.sync_enabled} class:badge-off={!settings.sync_enabled}>
+        {settings.sync_enabled ? 'ON' : 'OFF'}
+      </span>
+    </div>
+    <div class="status-row">
+      <span>Last Sync:</span>
+      <span>{formatTimestamp(settings.last_sync_at)}</span>
+    </div>
+    <div class="status-row">
+      <span>Status:</span>
+      <span class:status-success={settings.last_sync_status === 'success'} class:status-error={settings.last_sync_status === 'error'}>
+        {settings.last_sync_status || 'never'}
+      </span>
+    </div>
+    {#if settings.last_sync_message}
+      <div class="status-row">
+        <span>Message:</span>
+        <span>{settings.last_sync_message}</span>
+      </div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Fetches the buyer list directly from FairEntry (`fairentry-api` v0.2.0) on a configurable interval instead of requiring a manual Excel re-export/upload during the auction
- New "FairEntry Auto-Sync" panel on the Buyer List tab: username/password/fair title/interval, Save Settings, Enable/Disable, Sync Now, and a live status readout (last sync time, status, message)
- Manual drag-and-drop Excel upload is untouched and still works as the emergency override; using it auto-disables auto-sync and updates the status live
- Merge policy matches the existing Excel importer exactly: upsert by identifier, never delete (a buyer may already have bid history)
- Credentials are encrypted at rest (Fernet, key derived from `SECRET_KEY`) and never sent back to the frontend
- After 3 consecutive sync failures, auto-sync disables itself with a clear error rather than retrying forever silently

## Bugs found and fixed while dogfooding this against a real FairEntry account
- The background sync-loop task was created via `asyncio.create_task(...)` with no reference kept — asyncio only holds a weak reference to tasks, so it could be silently garbage-collected mid-run. Now held on `app.state`.
- `broadcast_message` mutated the `websockets` list while iterating it directly, which can skip a live client's turn when a dead connection ahead of it gets pruned in the same pass. Fixed to iterate a snapshot copy.
- The admin frontend's WebSocket had no reconnect logic, so any drop (e.g. a backend restart) silently froze all live updates (lot/bid/log/FairEntry status) until a manual page reload.
- The big one: `fairentry_sync.py` reached the broadcaster via `from main import broadcast_message`. Since the app is launched as `python backend/main.py`, that file loads as module `__main__`, not `main` — so the import silently re-imported `main.py` a second time, re-running its top-level code and creating a second, permanently-empty `websockets` list. Every automatic sync's broadcast was going into that void, while manual actions (Sync Now/Save/Toggle) looked fine only because they separately re-fetch over HTTP. Fixed by moving the shared websocket list/broadcaster into `ws_manager.py`, imported normally by both modules.

## Test plan
- [x] `pip install -r backend/requirements.txt` resolves the git dependency cleanly
- [x] `npm run build` in `frontend/` is clean
- [x] Verified against a real FairEntry account: enabling auto-sync fetches immediately; a 1-minute interval fires reliably (~1m2s observed) with no manual reload needed, confirmed via a raw WebSocket listener receiving the live push
- [x] Manual Excel upload still works unchanged and correctly auto-disables sync with the badge updating live
- [x] 3 consecutive failures (bad credentials) auto-disables sync with a clear message
- [x] Settings persist across a backend restart; password is never exposed to the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)