### PR TITLE
Fix Docker build: install git for fairentry-api dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,13 @@ FROM python:3.12-alpine AS backend
 WORKDIR /app
 
 # Install system dependencies for Python packages
+# git is required by pip to fetch the fairentry-api dependency from its
+# git+https:// URL in requirements.txt
 RUN apk add --no-cache \
     gcc \
     musl-dev \
     libffi-dev \
+    git \
     && rm -rf /var/cache/apk/*
 
 # Copy backend requirements and install Python dependencies


### PR DESCRIPTION
## Summary
- `docker build` was failing because the Alpine backend stage never installed `git`, but `backend/requirements.txt` pulls `fairentry-api` from a `git+https://` URL, which `pip` can't resolve without it.
- Added `git` to the stage's `apk add` list.

## Test plan
- [x] `docker build -t auction-display-test .` completes successfully, including building the `fairentry-api` wheel
- [x] Smoke-tested the built image: container boots, `GET /api/state` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)