### PR TITLE
Fix Next Lot button skipping a lot on first click after login

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auction-frontend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/frontend/src/components/AdminConsole.svelte
+++ b/frontend/src/components/AdminConsole.svelte
@@ -210,6 +210,10 @@
   async function nextLot() {
     try {
       await makeAuthenticatedRequest(`${API_BASE}/api/lot/next`, { method: 'POST' });
+      // Don't rely solely on the WebSocket broadcast to reflect this: right
+      // after login (a fresh mount/reconnect), the socket may not have
+      // finished connecting yet, which would silently drop this update.
+      await fetchCurrentState();
     } catch (error) {
       alert('Failed to navigate to next lot: ' + error.message);
     }
@@ -218,6 +222,7 @@
   async function prevLot() {
     try {
       await makeAuthenticatedRequest(`${API_BASE}/api/lot/prev`, { method: 'POST' });
+      await fetchCurrentState();
     } catch (error) {
       alert('Failed to navigate to previous lot: ' + error.message);
     }


### PR DESCRIPTION
## Summary
- `nextLot()`/`prevLot()` in `AdminConsole.svelte` relied entirely on the WebSocket `state` broadcast to update the admin's own screen. Right after login (which remounts the console and reopens the socket), the very first click's broadcast could fire before the socket finished connecting, so the update was silently dropped — the backend's lot index still advanced, but the admin's screen didn't. The next click would then jump straight to the following lot, silently skipping one entirely.
- Both handlers now re-fetch `/api/state` directly after their POST succeeds, so the actor's own view is never dependent on WebSocket connection timing.
- Bumped `frontend/package.json` patch version to 1.0.1.

## Test plan
- Reproduced the bug in a real browser (Playwright) against the dev servers by artificially delaying the WebSocket connect on login: confirmed the first "Next Lot" click showed no change and the second click jumped from lot 1 straight to lot 3, silently skipping lot 2 — while the backend's `current_lot_index` had correctly advanced through every lot.
- Re-ran the identical scenario against the fix: the first click after login now correctly reflects the very next lot every time, confirmed via screenshots and `/api/state` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)