### PR TITLE
Add read-only /reviewer screen for double-checking recorded buyers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -227,6 +227,34 @@ async def get_sale(db: Session = Depends(get_db)):
         for lot in lots
     ]
 
+@app.get("/api/review/lots")
+async def get_review_lots(db: Session = Depends(get_db), user: dict = Depends(require_auth)):
+    """Full sale program with every lot's recorded bidders, for the /reviewer
+    screen. Read-only and unrelated to AuctionSession.current_lot_index -
+    navigation on that screen is a purely local frontend index."""
+    lots = ordered_lots(db).all()
+    lot_ids = [lot.id for lot in lots]
+    rows = (
+        db.query(BidderLot, Buyer)
+        .join(Buyer, BidderLot.buyer_id == Buyer.id)
+        .filter(BidderLot.lot_id.in_(lot_ids))
+        .all()
+    )
+    bidders_by_lot = {}
+    for bidder_lot, buyer in rows:
+        bidders_by_lot.setdefault(bidder_lot.lot_id, []).append(
+            {"Identifier": buyer.identifier, "Name": buyer.name}
+        )
+    return [
+        {
+            "LotNumber": lot.lot_number,
+            "StudentName": lot.student_name,
+            "Department": lot.department,
+            "Bidders": bidders_by_lot.get(lot.id, []),
+        }
+        for lot in lots
+    ]
+
 @app.get("/api/buyers")
 async def get_buyers(db: Session = Depends(get_db)):
     buyers = db.query(Buyer).all()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,6 +3,7 @@
   import AdminConsole from './components/AdminConsole.svelte';
   import AuctioneerDisplay from './components/AuctioneerDisplay.svelte';
   import PublicDisplay from './components/PublicDisplay.svelte';
+  import ReviewerDisplay from './components/ReviewerDisplay.svelte';
   import Login from './components/Login.svelte';
   import { isAuthenticated } from './utils/auth.js';
 
@@ -14,6 +15,8 @@
     switch(currentPath) {
       case '/admin':
         return authenticated ? AdminConsole : Login;
+      case '/reviewer':
+        return authenticated ? ReviewerDisplay : Login;
       case '/auctioneer':
         return AuctioneerDisplay;
       case '/public':

--- a/frontend/src/components/ReviewerDisplay.svelte
+++ b/frontend/src/components/ReviewerDisplay.svelte
@@ -1,0 +1,274 @@
+<script>
+    import { onMount, onDestroy } from 'svelte';
+    import { makeAuthenticatedRequest } from '../utils/auth.js';
+
+    const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+
+    let lots = [];
+    let currentIndex = 0;
+    let loading = true;
+    let error = '';
+    let ws;
+    let jumpLotNumber = '';
+    let jumpError = '';
+
+    $: currentLot = lots[currentIndex] || null;
+    $: if (jumpLotNumber) jumpError = '';
+
+    async function fetchLots() {
+        try {
+            const res = await makeAuthenticatedRequest(`${API_BASE}/api/review/lots`);
+            if (res.ok) {
+                lots = await res.json();
+                if (currentIndex >= lots.length) currentIndex = Math.max(0, lots.length - 1);
+                error = '';
+            } else {
+                error = 'Failed to load sale data.';
+            }
+        } catch (err) {
+            error = 'Failed to load sale data.';
+        } finally {
+            loading = false;
+        }
+    }
+
+    function prevLot() {
+        if (currentIndex > 0) currentIndex -= 1;
+    }
+
+    function nextLot() {
+        if (currentIndex < lots.length - 1) currentIndex += 1;
+    }
+
+    function jumpToLot() {
+        const target = jumpLotNumber.trim();
+        if (!target) return;
+
+        const index = lots.findIndex((lot) => String(lot.LotNumber).trim() === target);
+        if (index === -1) {
+            jumpError = `Lot ${target} not found.`;
+            return;
+        }
+        currentIndex = index;
+        jumpError = '';
+        jumpLotNumber = '';
+    }
+
+    function handleJumpKeyPress(e) {
+        if (e.key === 'Enter') jumpToLot();
+    }
+
+    onMount(() => {
+        fetchLots();
+
+        ws = new WebSocket(API_BASE.replace('http', 'ws') + '/ws');
+        ws.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+            if (data.type === 'bid_update' || data.type === 'state' || data.type === 'sale_updated') {
+                fetchLots();
+            }
+        };
+    });
+
+    onDestroy(() => {
+        if (ws) ws.close();
+    });
+</script>
+
+<style>
+    .container {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        font-family: Arial, sans-serif;
+        box-sizing: border-box;
+        padding: 1.5rem;
+    }
+
+    .header {
+        border: 2px solid black;
+        border-radius: 8px;
+        padding: 1rem 1.5rem;
+        background-color: white;
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .nav-button {
+        padding: 0.75rem 1.25rem;
+        font-size: 1.1rem;
+        background: #007bff;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .nav-button:hover:not(:disabled) {
+        background: #0056b3;
+    }
+
+    .nav-button:disabled {
+        background: #6c757d;
+        cursor: not-allowed;
+    }
+
+    .lot-summary {
+        flex: 1;
+        text-align: center;
+    }
+
+    .lot-title {
+        font-size: 1.6rem;
+        font-weight: bold;
+    }
+
+    .lot-subtitle {
+        font-size: 1.1rem;
+        color: #444;
+        margin-top: 0.25rem;
+    }
+
+    .lot-position {
+        font-size: 0.95rem;
+        color: #777;
+        margin-top: 0.25rem;
+    }
+
+    .buyers-section {
+        flex: 1;
+        margin-top: 1.5rem;
+        border: 2px solid black;
+        border-radius: 8px;
+        background: white;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .buyers-list {
+        overflow-y: auto;
+        flex: 1;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    th, td {
+        border: 1px solid #ccc;
+        padding: 0.75rem 1rem;
+        text-align: left;
+        font-size: 1.1rem;
+    }
+
+    th {
+        background: #f0f0f0;
+        position: sticky;
+        top: 0;
+    }
+
+    .empty-message {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.2rem;
+        font-style: italic;
+        color: #777;
+    }
+
+    .status-message {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.2rem;
+        color: #777;
+    }
+
+    .jump-section {
+        margin-top: 1.5rem;
+        border: 2px solid black;
+        border-radius: 8px;
+        padding: 1rem 1.5rem;
+        background-color: white;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .jump-section label {
+        font-size: 1.1rem;
+        font-weight: bold;
+    }
+
+    .jump-section input {
+        padding: 0.6rem;
+        font-size: 1.1rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        width: 140px;
+    }
+
+    .jump-error {
+        color: #dc3545;
+        font-size: 0.95rem;
+    }
+</style>
+
+<div class="container">
+    <div class="header">
+        <button class="nav-button" on:click={prevLot} disabled={currentIndex <= 0}>&larr; Previous</button>
+        <div class="lot-summary">
+            {#if currentLot}
+                <div class="lot-title">Lot {currentLot.LotNumber} &mdash; {currentLot.StudentName}</div>
+                <div class="lot-subtitle">{currentLot.Department}</div>
+                <div class="lot-position">Lot {currentIndex + 1} of {lots.length}</div>
+            {:else if !loading}
+                <div class="lot-title">No lots available</div>
+            {/if}
+        </div>
+        <button class="nav-button" on:click={nextLot} disabled={currentIndex >= lots.length - 1}>Next &rarr;</button>
+    </div>
+
+    <div class="buyers-section">
+        {#if loading}
+            <div class="status-message">Loading sale data&hellip;</div>
+        {:else if error}
+            <div class="status-message">{error}</div>
+        {:else if !currentLot || (currentLot.Bidders || []).length === 0}
+            <div class="empty-message">No buyers recorded for this lot yet.</div>
+        {:else}
+            <div class="buyers-list">
+                <table>
+                    <thead>
+                        <tr><th>Buyer #</th><th>Buyer Name</th></tr>
+                    </thead>
+                    <tbody>
+                        {#each currentLot.Bidders as buyer}
+                            <tr><td>{buyer.Identifier}</td><td>{buyer.Name}</td></tr>
+                        {/each}
+                    </tbody>
+                </table>
+            </div>
+        {/if}
+    </div>
+
+    <div class="jump-section">
+        <label for="jump-lot-number">Jump to Lot #:</label>
+        <input
+            id="jump-lot-number"
+            type="text"
+            bind:value={jumpLotNumber}
+            on:keypress={handleJumpKeyPress}
+            placeholder="Lot number"
+        />
+        <button class="nav-button" on:click={jumpToLot}>Go</button>
+        {#if jumpError}
+            <span class="jump-error">{jumpError}</span>
+        {/if}
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- New `/reviewer` route (login required) for a clerk to browse every lot and see the buyers already recorded for it — a backoffice double-check tool, not a live-show control.
- Previous/Next buttons plus a "Jump to Lot #" field to navigate; navigation is purely local frontend state, so it can never move the live current lot.
- New `GET /api/review/lots` endpoint (authenticated) returns every lot with its recorded bidders in one query, reusing the existing `ordered_lots()` helper so it stays in sync with whatever Sale Order is active.
- The screen listens on the existing `/ws` connection to auto-refresh when new bids are recorded elsewhere, but never sends anything over it and never calls any lot/bidder/theme-mutating endpoint.

## Test plan
- [x] `npm run build` succeeds
- [x] Backend: `/api/review/lots` returns `401` with no token, correct joined lot+bidder JSON with a valid token
- [x] Browser: logged in at `/reviewer`, confirmed Previous/Next paging and buyer lists match `/admin`, confirmed jump-to-lot works for a valid lot and shows an inline error for an invalid one
- [x] Confirmed `/reviewer` navigation does not affect `/public` or `/auctioneer`'s current lot

🤖 Generated with [Claude Code](https://claude.com/claude-code)